### PR TITLE
Display form field errors from API server

### DIFF
--- a/eligibility_verification/core/templates/core/includes/form.html
+++ b/eligibility_verification/core/templates/core/includes/form.html
@@ -51,6 +51,9 @@
                 var sub = $("input[type=submit]", this);
                 sub.attr("style", attrs.join(";"));
                 sub.val("{{ form.submitting_value }}");
+
+                $(".form-group", this).removeClass("with-errors");
+                $(".error-message", this).remove();
             });
         });
     </script>

--- a/eligibility_verification/core/templates/core/includes/form.html
+++ b/eligibility_verification/core/templates/core/includes/form.html
@@ -4,7 +4,11 @@
     {% csrf_token %}
 
     {% for field in form %}
+    {% if field.errors %}
+    <div class="form-group with-errors">
+    {% else %}
     <div class="form-group">
+    {% endif %}
         <label for="{{ field.id_for_label }}" class="form-control-label">
             {{ field.label }}
             {% if field.field.required %}<span class="required-label">*</span>{% endif %}
@@ -19,7 +23,7 @@
         {% endif %}
 
         {% if field.errors %}
-        <div class="invalid-feedback">
+        <div class="error-message">
             {% for error in field.errors %}
             <p>{{ error }}</p>
             {% endfor %}

--- a/eligibility_verification/eligibility/api.py
+++ b/eligibility_verification/eligibility/api.py
@@ -11,6 +11,11 @@ import requests
 from eligibility_verification.settings import ALLOWED_HOSTS
 
 
+class Error(ValueError):
+    """Exception for Eligibility Verification API errors."""
+    pass
+
+
 class Token():
     """Eligibility Verification API request token."""
 
@@ -87,7 +92,7 @@ class TokenResponse(Response):
     """Eligibility Verification API response token."""
 
     def __init__(self, response, agency, verifier):
-        super().__init__(response.status_code, message=response.text)
+        super().__init__(response.status_code)
 
         # bail early for remote server errors
         if self.status_code >= 500:

--- a/eligibility_verification/eligibility/forms.py
+++ b/eligibility_verification/eligibility/forms.py
@@ -24,3 +24,26 @@ class EligibilityVerificationForm(forms.Form):
 
     submit_value = "Check status"
     submitting_value = "Checking"
+
+    _error_messages = {
+        "invalid": "Check your input. The format looks wrong.",
+        "missing": "This field is required."
+    }
+
+    def add_api_errors(self, form_errors):
+        """Handle errors passed back from API server related to submitted form values."""
+
+        for form_error in form_errors:
+            field_errors = [
+                (field, code)
+                for field, code in form_error.items()
+                if field in self.fields
+            ]
+
+            validation_errors = {
+                field: forms.ValidationError(self._error_messages.get(code, "Error"), code=code)
+                for (field, code) in field_errors
+            }
+
+            for (field, err) in validation_errors.items():
+                self.add_error(field, err)

--- a/eligibility_verification/static/css/styles.css
+++ b/eligibility_verification/static/css/styles.css
@@ -56,10 +56,6 @@ footer {
     color: #046b99;
 }
 
-.form-group:nth-last-of-type(2) {
-    margin-bottom: 2rem;
-}
-
 .form-control {
     border-radius: 0.25rem;
     border-color: #212121;
@@ -77,6 +73,14 @@ footer {
 
 .required-label {
     color: #000;
+}
+
+.form-group:not(.with-errors) {
+    margin-bottom: 2.375rem;
+}
+
+.form-group:not(.with-errors):nth-last-of-type(2) {
+    margin-bottom: 3.375rem;
 }
 
 .form-group.with-errors label,

--- a/eligibility_verification/static/css/styles.css
+++ b/eligibility_verification/static/css/styles.css
@@ -75,8 +75,22 @@ footer {
     border-radius: 0.3rem;
 }
 
-.invalid-feedback {
-    display: block;
+.required-label {
+    color: #000;
+}
+
+.form-group.with-errors label,
+.form-group.with-errors .required-label {
+    color: #DE0C0C;
+}
+
+.form-group.with-errors .form-control {
+    border-color: #DE0C0C;
+}
+
+.form-group.with-errors .error-message {
+    font-size: 14px;
+    padding-left: 1rem;
 }
 
 .media-list {


### PR DESCRIPTION
The API supports HTTP 400 responses with two types of field errors:

* `missing`
* `invalid`

The former should never happen since our form requires all fields. The latter is defined and validated by the Verification Server, so this gives the Server a way to acknowledge an invalid field without divulging specifics.

Messages for each class of error are hard-coded in the form for now.